### PR TITLE
Fix : httpx.Client removed argument "proxies"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 { name = "Groq", email = "support@groq.com" },
 ]
 dependencies = [
-    "httpx>=0.23.0, <1",
+    "httpx>=0.23.0, <0.28.0",
     "pydantic>=1.9.0, <3",
     "typing-extensions>=4.7, <5",
     "anyio>=3.5.0, <5",


### PR DESCRIPTION
TypeError: Client.__init__() got an unexpected keyword argument 'proxies' ---.
In httpx==0.28.0 version, the following error occurred For an immediate workaround, specifying a version lower than 0.28.0 as the required version should fix it.