### PR TITLE
Typing Improvements for Transcription Object

### DIFF
--- a/src/groq/types/audio/transcription.py
+++ b/src/groq/types/audio/transcription.py
@@ -1,10 +1,20 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from ..._models import BaseModel
+from typing import List, Union
 
 __all__ = ["Transcription"]
 
+class Word(BaseModel):
+    word: str
+    """The transcribed word"""
+    start: float
+    """The start of the word (in milliseconds)"""
+    end: float
+    """The end of the word (in milliseconds)"""
 
 class Transcription(BaseModel):
     text: str
     """The transcribed text."""
+    words: Union[List[Word], None]
+    """The words in the transcription depending on the granularity setting."""

--- a/src/groq/types/audio/transcription.py
+++ b/src/groq/types/audio/transcription.py
@@ -10,3 +10,5 @@ class Transcription(BaseModel):
     """The transcribed text."""
     words: Union[List[dict], None]
     """The words in the transcription depending on the granularity setting."""
+    segments: Union[List[dict], None]
+    """The segments in the transcription depending on the granularity setting."""

--- a/src/groq/types/audio/transcription.py
+++ b/src/groq/types/audio/transcription.py
@@ -5,16 +5,8 @@ from typing import List, Union
 
 __all__ = ["Transcription"]
 
-class Word(BaseModel):
-    word: str
-    """The transcribed word"""
-    start: float
-    """The start of the word (in milliseconds)"""
-    end: float
-    """The end of the word (in milliseconds)"""
-
 class Transcription(BaseModel):
     text: str
     """The transcribed text."""
-    words: Union[List[Word], None]
+    words: Union[List[dict], None]
     """The words in the transcription depending on the granularity setting."""


### PR DESCRIPTION
## What this PR does

Adds the `Word` type to the `Transcription` object. When calling https://console.groq.com/docs/api-reference#audio-translation and adding the `timestamp_granularities` param you will get back both the `text` and the `words` object