### PR TITLE
fix(_transform): guard against IndexError on bare dict annotation

### DIFF
--- a/src/groq/_utils/_transform.py
+++ b/src/groq/_utils/_transform.py
@@ -180,7 +180,10 @@ def _transform_recursive(
         return _transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
+        args = get_args(stripped_type)
+        if not args:
+            return data
+        items_type = args[1]
         return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (
@@ -346,7 +349,10 @@ async def _async_transform_recursive(
         return await _async_transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
+        args = get_args(stripped_type)
+        if not args:
+            return data
+        items_type = args[1]
         return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -455,6 +455,15 @@ async def test_strips_notgiven(use_async: bool) -> None:
 
 @parametrize
 @pytest.mark.asyncio
+async def test_bare_dict_annotation_no_indexerror(use_async: bool) -> None:
+    # A bare `dict` annotation (no type args) previously raised IndexError because
+    # get_args(dict) returns () and the code unconditionally indexed [1].
+    result = await transform({"key": {"a": 1}}, Annotated[dict, PropertyInfo(alias="key")], use_async)
+    assert result == {"key": {"a": 1}}
+
+
+@parametrize
+@pytest.mark.asyncio
 async def test_strips_omit(use_async: bool) -> None:
     assert await transform({"foo_bar": "bar"}, Foo1, use_async) == {"fooBar": "bar"}
     assert await transform({"foo_bar": omit}, Foo1, use_async) == {}


### PR DESCRIPTION
## What's broken

Calling `transform()` or `async_transform()` with a mapping value typed as a bare `dict` (no type parameters, e.g. `Annotated[dict, PropertyInfo(alias="key")]`) raises `IndexError`. The same crash occurs in the async counterpart `_async_transform_recursive`.

Repro:

```python
from typing_extensions import Annotated
from groq._utils._transform import transform, PropertyInfo
transform({"key": {"a": 1}}, Annotated[dict, PropertyInfo(alias="key")])
# IndexError: tuple index out of range
```

## Why it happens

`get_args(dict)` returns an empty tuple. Both `_transform_recursive` (line 183) and `_async_transform_recursive` (line 349) unconditionally index `[1]` without checking whether type args exist.

## Fix

Added a bounds check in both functions: if `get_args(stripped_type)` is empty, return `data` unchanged. When type args are present the existing `dict[K, V]` path continues to work as before.

## Test

Added `test_bare_dict_annotation_no_indexerror` which asserts that a mapping passed against a bare `dict` annotation is returned unchanged (runs for both sync and async paths).