### PR TITLE
chore: update CODEOWNERS (add @pmichalina-groq, remove @gradenr and @bklieger-groq)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @bklieger-groq @andrewtlw @cwilmott-groq @pmichalina-groq
+* @andrewtlw @cwilmott-groq @pmichalina-groq

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @gradenr @bklieger-groq @andrewtlw @cwilmott-groq @pmichalina-groq
+* @bklieger-groq @andrewtlw @cwilmott-groq @pmichalina-groq

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @gradenr @bklieger-groq @andrewtlw @cwilmott-groq
+* @gradenr @bklieger-groq @andrewtlw @cwilmott-groq @pmichalina-groq


### PR DESCRIPTION
Adds @pmichalina-groq as a code owner and removes @gradenr and @bklieger-groq, aligning with groq-typescript. The `main` ruleset requires a code-owner review, so today I can't approve/merge routine PRs (e.g. dependabot bumps). This lets me help keep those moving.