### PR TITLE
chore(deps): update lock files to fix known vulnerabilities (GC1-104)

### DIFF
--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -12,7 +12,7 @@
 -e file:.
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.13.3
+aiohttp==3.14.3
     # via groq
     # via httpx-aiohttp
 aiosignal==1.4.0
@@ -48,7 +48,7 @@ exceptiongroup==1.3.1
     # via pytest
 execnet==2.1.2
     # via pytest-xdist
-filelock==3.19.1
+filelock==3.32.2
     # via virtualenv
 frozenlist==1.8.0
     # via aiohttp
@@ -65,7 +65,7 @@ httpx-aiohttp==0.1.12
     # via groq
 humanize==4.13.0
     # via nox
-idna==3.11
+idna==3.18
     # via anyio
     # via httpx
     # via yarl
@@ -102,14 +102,14 @@ pydantic==2.12.5
     # via groq
 pydantic-core==2.41.5
     # via pydantic
-pygments==2.19.2
+pygments==2.20.0
     # via pytest
     # via rich
 pyright==1.1.399
-pytest==8.4.2
+pytest==9.1.1
     # via pytest-asyncio
     # via pytest-xdist
-pytest-asyncio==1.2.0
+pytest-asyncio==1.4.0
 pytest-xdist==3.8.0
 python-dateutil==2.9.0.post0
     # via time-machine
@@ -127,6 +127,7 @@ tomli==2.4.0
     # via nox
     # via pytest
 typing-extensions==4.15.0
+    # via aiohttp
     # via aiosignal
     # via anyio
     # via exceptiongroup

--- a/requirements.lock
+++ b/requirements.lock
@@ -12,7 +12,7 @@
 -e file:.
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.13.3
+aiohttp==3.14.3
     # via groq
     # via httpx-aiohttp
 aiosignal==1.4.0
@@ -45,7 +45,7 @@ httpx==0.28.1
     # via httpx-aiohttp
 httpx-aiohttp==0.1.12
     # via groq
-idna==3.11
+idna==3.18
     # via anyio
     # via httpx
     # via yarl
@@ -62,6 +62,7 @@ pydantic-core==2.41.5
 sniffio==1.3.1
     # via groq
 typing-extensions==4.15.0
+    # via aiohttp
     # via aiosignal
     # via anyio
     # via exceptiongroup


### PR DESCRIPTION
Part of [GC1-104](https://linear.app/groq/issue/GC1-104/upgrade-groq-python-sdk-dependencies-and-pypi-auth).

## What

Update the rye lock files to remove all pinned versions that have published security advisories:

| Package | Old | New | Advisories |
|---|---|---|---|
| aiohttp | 3.13.3 | 3.14.3 | 24 GHSA advisories fixed in the 3.14.x line (e.g. GHSA-2fqr-mr3j-6wp8) |
| filelock | 3.19.1 | 3.32.2 | GHSA-qmgc-5h2g-mvrw, GHSA-w853-jp5j-5j7f |
| idna | 3.11 | 3.18 | GHSA-65pc-fj4g-8rjx |
| pygments | 2.19.2 | 2.20.0 | GHSA-5239-wwwm-4pmq |
| pytest | 8.4.2 | 9.1.1 | GHSA-6w46-j5rx-g56g |
| pytest-asyncio | 1.2.0 | 1.4.0 | none; required by pytest 9 |

All other pins are unchanged. pydantic stays at 2.12.5 on purpose: pydantic 2.13 adds a `polymorphic_serialization` parameter to `model_dump` / `model_dump_json`, and the generated overrides in `src/groq/_models.py` do not accept it yet, so pyright fails. That bump belongs in Stainless codegen.

## Verification

- `rye lock --all-features --update <pkg>...` with rye 0.44.0 (the CI-pinned version)
- `./scripts/lint` passes (ruff, pyright, mypy, import check)
- `./scripts/test` passes: 732 passed, 62 skipped, plus the pydantic-v1 nox session
- OSV batch scan of the updated `requirements-dev.lock`: 0 known vulnerabilities across all 59 pins

## Note

Dependabot vulnerability alerts are disabled on this repository, which is why these advisories were silent. A repository admin should enable them (Settings -> Advanced Security -> Dependabot alerts). Tracked in GC1-104.

Companion PR: #281 switches PyPI publishing to Trusted Publishing (OIDC). The two PRs are independent; this one can merge first.
