### PR TITLE
chore(ci): publish to PyPI with Trusted Publishing / OIDC (GC1-104)

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,6 +1,10 @@
 # This workflow is triggered when a GitHub release is created.
 # It can also be run manually to re-publish to PyPI in case it failed for some reason.
 # You can run this workflow by navigating to https://www.github.com/groq/groq-python/actions/workflows/publish-pypi.yml
+#
+# Publishing authenticates with PyPI through Trusted Publishing (GitHub OIDC),
+# so no PyPI API token is required: https://docs.pypi.org/trusted-publishers/
+# PyPI generates PEP 740 attestations for the uploaded files automatically.
 name: Publish PyPI
 on:
   workflow_dispatch:
@@ -12,6 +16,10 @@ jobs:
   publish:
     name: publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required to mint the OIDC token for PyPI Trusted Publishing.
+      id-token: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -24,8 +32,8 @@ jobs:
           RYE_VERSION: '0.44.0'
           RYE_INSTALL_OPTION: '--yes'
 
+      - name: Build distributions
+        run: rye build --clean
+
       - name: Publish to PyPI
-        run: |
-          bash ./bin/publish-pypi
-        env:
-          PYPI_TOKEN: ${{ secrets.GROQ_PYPI_TOKEN || secrets.PYPI_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/release-doctor.yml
+++ b/.github/workflows/release-doctor.yml
@@ -17,5 +17,3 @@ jobs:
       - name: Check release environment
         run: |
           bash ./bin/check-release-environment
-        env:
-          PYPI_TOKEN: ${{ secrets.GROQ_PYPI_TOKEN || secrets.PYPI_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ the changes aren't made through the automated pipeline, you may want to make rel
 
 ### Publish with a GitHub workflow
 
-You can release to package managers by using [the `Publish PyPI` GitHub action](https://www.github.com/groq/groq-python/actions/workflows/publish-pypi.yml). This requires a setup organization or repository secret to be set up.
+You can release to package managers by using [the `Publish PyPI` GitHub action](https://www.github.com/groq/groq-python/actions/workflows/publish-pypi.yml). The workflow authenticates with [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (GitHub OIDC), so it does not need a PyPI token secret. PyPI generates [PEP 740 attestations](https://docs.pypi.org/attestations/) for the uploaded files automatically.
 
 ### Publish manually
 

--- a/bin/check-release-environment
+++ b/bin/check-release-environment
@@ -2,9 +2,9 @@
 
 errors=()
 
-if [ -z "${PYPI_TOKEN}" ]; then
-  errors+=("The PYPI_TOKEN secret has not been set. Please set it in either this repository's secrets or your organization secrets.")
-fi
+# PyPI publishing authenticates with Trusted Publishing (GitHub OIDC) in the
+# publish-pypi workflow, so no PyPI token is required in the release
+# environment. See https://docs.pypi.org/trusted-publishers/
 
 lenErrors=${#errors[@]}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ classifiers = [
 [project.urls]
 Homepage = "https://github.com/groq/groq-python"
 Repository = "https://github.com/groq/groq-python"
+Documentation = "https://console.groq.com/docs"
+Changelog = "https://github.com/groq/groq-python/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 aiohttp = ["aiohttp", "httpx_aiohttp>=0.1.9"]


### PR DESCRIPTION
Part of [GC1-104](https://linear.app/groq/issue/GC1-104/upgrade-groq-python-sdk-dependencies-and-pypi-auth).

## What

Replace token-based PyPI publishing with [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (GitHub OIDC):

- `publish-pypi` workflow now builds with rye and uploads with `pypa/gh-action-pypi-publish` (pinned to the v1.14.2 commit). The job gets `id-token: write` and no longer reads `PYPI_TOKEN` / `GROQ_PYPI_TOKEN`.
- PyPI generates [PEP 740 attestations](https://docs.pypi.org/attestations/) for the uploaded files automatically, so every release is signed (Sigstore) and shows verified provenance on pypi.org. Current releases (1.6.0 and earlier) have no provenance.
- `release-doctor` and `bin/check-release-environment` no longer require the token secret.
- `bin/publish-pypi` stays unchanged as a manual, token-based escape hatch (see CONTRIBUTING.md).
- `pyproject.toml` gains `Documentation` and `Changelog` project URLs. With Trusted Publishing active, PyPI also marks the GitHub URLs as verified.

## DO NOT MERGE until PyPI is configured

The `groq` project on PyPI must have a Trusted Publisher configured **before** this merges, or the next release will fail to publish. An owner of https://pypi.org/project/groq/ must:

1. Open https://pypi.org/manage/project/groq/settings/publishing/
2. Add a GitHub publisher with exactly:
   - Owner: `groq`
   - Repository: `groq-python`
   - Workflow name: `publish-pypi.yml`
   - Environment: leave blank
3. After the first successful OIDC publish, delete the `GROQ_PYPI_TOKEN` / `PYPI_TOKEN` GitHub secrets and revoke the PyPI API token.

## Verification

- `rye build --clean` succeeds; sdist PKG-INFO shows the new project URLs and `Author-email: Groq <support@groq.com>`
- `uvx yamllint` on both workflows: no errors (only pre-existing line-length warnings)
- `bash -n bin/check-release-environment` passes
- After the first release under this workflow, https://pypi.org/project/groq/#files should show provenance/attestations per file

## Note on Stainless

These workflow files are Stainless-generated templates. If a future codegen run conflicts with this change, the publishing config should be moved into the Stainless project config so the generator emits the OIDC workflow.

Companion PR: #280 updated the dependency lock files (merged 2026-08-18). This branch is rebased on top of it.
