### PR TITLE
feat(chat): add Qwen3.8 reasoning guidance

### DIFF
--- a/src/groq/resources/chat/completions.py
+++ b/src/groq/resources/chat/completions.py
@@ -70,6 +70,7 @@ class Completions(SyncAPIResource):
                 "openai/gpt-oss-20b",
                 "qwen/qwen3-32b",
                 "qwen/qwen3.6-27b",
+                "qwen/qwen3.8-27b",
             ],
         ],
         citation_options: Optional[Literal["enabled", "disabled"]] | Omit = omit,
@@ -378,8 +379,11 @@ class Completions(SyncAPIResource):
               Positive values penalize new tokens based on whether they appear in the text so
               far, increasing the model's likelihood to talk about new topics.
 
-          reasoning_effort: qwen3 models support the following values Set to 'none' to disable reasoning.
-              Set to 'default' or null to let Qwen reason.
+          reasoning_effort: qwen3 models support `none` to disable reasoning and `default` or null
+              to use the model default.
+
+              qwen/qwen3.8-27b additionally supports `low`, `medium`, and `high`. Its default
+              is `medium`; `high` selects the model's native `xhigh` mode.
 
               openai/gpt-oss-20b and openai/gpt-oss-120b support 'low', 'medium', or 'high'.
               'medium' is the default value.
@@ -739,6 +743,7 @@ class AsyncCompletions(AsyncAPIResource):
                 "openai/gpt-oss-20b",
                 "qwen/qwen3-32b",
                 "qwen/qwen3.6-27b",
+                "qwen/qwen3.8-27b",
             ],
         ],
         citation_options: Optional[Literal["enabled", "disabled"]] | Omit = omit,
@@ -859,8 +864,11 @@ class AsyncCompletions(AsyncAPIResource):
               Positive values penalize new tokens based on whether they appear in the text so
               far, increasing the model's likelihood to talk about new topics.
 
-          reasoning_effort: qwen3 models support the following values Set to 'none' to disable reasoning.
-              Set to 'default' or null to let Qwen reason.
+          reasoning_effort: qwen3 models support `none` to disable reasoning and `default` or null
+              to use the model default.
+
+              qwen/qwen3.8-27b additionally supports `low`, `medium`, and `high`. Its default
+              is `medium`; `high` selects the model's native `xhigh` mode.
 
               openai/gpt-oss-20b and openai/gpt-oss-120b support 'low', 'medium', or 'high'.
               'medium' is the default value.

--- a/src/groq/types/chat/completion_create_params.py
+++ b/src/groq/types/chat/completion_create_params.py
@@ -54,6 +54,7 @@ class CompletionCreateParams(TypedDict, total=False):
                 "openai/gpt-oss-20b",
                 "qwen/qwen3-32b",
                 "qwen/qwen3.6-27b",
+                "qwen/qwen3.8-27b",
             ],
         ]
     ]
@@ -183,8 +184,11 @@ class CompletionCreateParams(TypedDict, total=False):
 
     reasoning_effort: Optional[Literal["none", "default", "low", "medium", "high"]]
     """
-    qwen3 models support the following values Set to 'none' to disable reasoning.
-    Set to 'default' or null to let Qwen reason.
+    qwen3 models support `none` to disable reasoning and `default` or null to use
+    the model default.
+
+    qwen/qwen3.8-27b additionally supports `low`, `medium`, and `high`. Its default
+    is `medium`; `high` selects the model's native `xhigh` mode.
 
     openai/gpt-oss-20b and openai/gpt-oss-120b support 'low', 'medium', or 'high'.
     'medium' is the default value.


### PR DESCRIPTION
## Summary

- add qwen/qwen3.8-27b to Chat model autocomplete
- document none/default/low/medium/high support
- clarify that public high selects the model-native xhigh mode

Generated-surface companion to groq/orion#7272.

## Validation

- ruff format --check
- ruff check
- pyright on touched generated modules
- mypy
- import smoke test

Linear: GC1-423